### PR TITLE
Add an option for tag setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,5 @@ Useful Go functions (based on the fact that I've needed them in more than one
 project.)
 
 * `Editinacme` is a pure-Go `plumber`-free function largely mimic-ing the
-operation of the `B` command from Plan9Port.
+operation of the `B` command from Plan9Port. Note the availability of the
+`Addtotag` option to append text to the tag.

--- a/_examples/b/main.go
+++ b/_examples/b/main.go
@@ -19,6 +19,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("can't abs %q: %v", flag.Arg(0), err)
 	}
-	
-	gozen.Editinacme(ap)
+
+	gozen.Editinacme(ap, gozen.Addtotag("hello, added with b"))
 }

--- a/editinacme.go
+++ b/editinacme.go
@@ -1,6 +1,7 @@
 package gozen
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -11,7 +12,7 @@ import (
 // Editinacme directly opens plumbstring in Acme/Edwood because regular
 // plumb can't handle the paths found in the Go package database.
 // Note that paths in plumbstring need to be absolute.
-func Editinacme(plumbstring string) error {
+func Editinacme(plumbstring string, opts ...option) error {
 	chunks := strings.Split(plumbstring, ":")
 	if len(chunks) > 2 {
 		return fmt.Errorf("plumbhelper bad plumb address string")
@@ -77,5 +78,13 @@ func Editinacme(plumbstring string) error {
 		return fmt.Errorf("plumbhelper win.Addr: %v", err)
 	}
 
-	return nil
+	// This general structure permits (I think) adding an arbitrary number of
+	// additional customization settings (e.g. setting the dump command or
+	// the like.)
+	allerrs := make([]error, 0)
+	for _, opt := range opts {
+		allerrs = append(allerrs, opt(win))
+	}
+
+	return errors.Join(allerrs...)
 }

--- a/options.go
+++ b/options.go
@@ -1,0 +1,20 @@
+package gozen
+
+import (
+	"9fans.net/go/acme"
+)
+
+// Pike-style options: [command center: Self-referential functions and the design of options](https://commandcenter.blogspot.com/2014/01/self-referential-functions-and-design.html)
+// I have written the simplest possible code that I need _now_. It is conceivable
+// that I want something more sophisticated like https://golang.design/research/generic-option/#fn:1
+
+type option func(*acme.Win) error
+
+// Addtotag returns an option for Editinacme that adds the provided string
+// to the Acme/Edwood tag.
+func Addtotag(v string) option {
+	return func(w *acme.Win) error {
+		// capture v in a closure.
+		return w.Fprintf("tag", v)
+	}
+}


### PR DESCRIPTION
Add the Addtotag Pike-functional-option to permit setting
the Acme/Edwood tag as part of invoking Editinacme.
